### PR TITLE
build(docker): remove REDIS_URL ARG from ini.Dockerfile

### DIFF
--- a/init.Dockerfile
+++ b/init.Dockerfile
@@ -1,10 +1,5 @@
 FROM node:12.16.3-alpine
 
-
-ARG REDIS_URL
-
-ENV REDIS_URL=$REDIS_URL
-
 RUN apk add --no-cache git
 
 WORKDIR /app


### PR DESCRIPTION
`REDIS_URL` is only required during `yarn cache:update`